### PR TITLE
Applied direct reply-to logic - next steps and feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a repo to accompany this [SO post.](https://stackoverflow.com/questions/
   - pika==1.0.1
   - rabbitmq:3.7.14 (run via [docker](https://hub.docker.com/_/rabbitmq))
 
+**NOTE!** Check the Update section at the bottom of this document for a list of things that have changed and why.
+
 ### Code Goals Explained
 
 I followed the official [RabbitMQ Documentation](https://www.rabbitmq.com/tutorials/tutorial-six-python.html) as to how to get started with RabbitMQ and Pika. I wanted to create reuseable code that uses RPC logic with multiple Clients and Servers. The general idea is the following: Multiple Clienrs can publish messages to an exchange (the default is used for now) and only one Server picks it up, processes it and sends a response to a callback queue. The Clients meanwhile looks for responses at the same callback queue. The response is read only when the correlation_id is identified.
@@ -14,7 +16,7 @@ I followed the official [RabbitMQ Documentation](https://www.rabbitmq.com/tutori
 
 Everything runs smoothly when a single Client is used. It does not matter if one or more (I have tried up until 4) Servers are used. The behavior is as expected. Messages are published, consumed once and a response is sent.
 
-### When the code fails
+### When the code fails (UPDATE: details at the end of this document)
 
 The problem occurs when (even with a single Server) more than one Clients are used. The easiest way to reproduce the issue is with 2 Clients and 1 Server. When one Client publishes a message, the Server picks it up and processes it. When the 2nd Client connects (it is actually the ```channel.basic_consume()``` command that breaks everything) then timeouts start to occur, even though the Server processes the messages correctly.
 
@@ -67,3 +69,15 @@ while True:
   connection.process_data_events()
 ```
 As the comment suggests, the `channel.basic_consume()` is when the trouble begins.
+___
+___
+### UPDATE
+After  investigating the [direct reply-to](https://www.rabbitmq.com/direct-reply-to.html) functionality of RabbitMQ I removed the explicit decleration of a `callback_queue` and instead now always use the `amq.rabbitmq.reply-to` "queue". Necessary changes were made to both Client and Server classes and the problems described above seem to be resolved. **I do not however understand why this works and the previous logic failed to produce the results I expected.**
+
+### Possible Future Work
+Transform this project into a robust RPC example with a detailed documentation explaining how everything works and why some decisions were made.
+
+### NonBlocking Connection?
+Now that this version is working some other issues were discovered, regarding the stability of the system. I now understand that a Blocking Connection may not be the best choice, but it is a solid start that helps properly graps the basic concepts. I would love to either expand this example to a RPC system with reconnect capabilities and/or create a NonBlocking Connection robust example.
+
+#### Feel free to comment on these thoughts and changes, all feedback is greatly appreciated.

--- a/Server.py
+++ b/Server.py
@@ -5,7 +5,6 @@ class BlockingServer(object):
     def __init__(self,
                  host='rabbit',
                  consume_queue='consume_lost',
-                 callback_queue='callback_lost',
                  timeout=60,
                  prefetch_count=1,
                  process=None,
@@ -17,7 +16,6 @@ class BlockingServer(object):
         self.timeout = timeout
         self.prefetch_count = prefetch_count
 
-        self.callback_queue = callback_queue
         self.process = process
 
         params = pika.ConnectionParameters(
@@ -40,7 +38,7 @@ class BlockingServer(object):
         properties = pika.BasicProperties(correlation_id=props.correlation_id)
         print(props.correlation_id)
         ch.basic_publish(exchange='',
-                         routing_key=self.callback_queue,
+                         routing_key=props.reply_to,
                          properties=properties,
                          body=str(response))
         ch.basic_ack(delivery_tag=method.delivery_tag)
@@ -50,6 +48,7 @@ class BlockingServer(object):
 
         print(" [x] Awaiting RPC requests")
         self.channel.start_consuming()
+
 
 # Example process function
 def fib(n):


### PR DESCRIPTION
I changed the callback_queue from a user-created one to `amq.rabbitmq.reply-to`. This has resolved the issues described in the README, but I fail to understand why the previous approach did not work.

Also, the code now always uses the direct reply-to logic, is this the best choice?

I would also like some feedback on the things to consider when expanding this code base to a client and server that can recover from connection issues and whether I should start compiling an example of a non-blocking connection.